### PR TITLE
Fix typo in products docs page

### DIFF
--- a/docs/core/reference/products.md
+++ b/docs/core/reference/products.md
@@ -372,10 +372,10 @@ Then we need to create our base option and it's values.
 $option = \Lunar\Models\ProductOption::create([
     'name' => [
         'en' => 'Colour',
-    ];
+    ],
     'label' => [
         'en' => 'Colour',
-    ];
+    ],
 ]);
 
 $blueOption = $option->values()->create([


### PR DESCRIPTION
A typo in options creation code example where the elements of the array where separated by `;` instead of `,`.